### PR TITLE
[MNT] Make tests for `Investor.setAllocation`

### DIFF
--- a/supabase/functions/backtest/investor/index.ts
+++ b/supabase/functions/backtest/investor/index.ts
@@ -5,7 +5,6 @@ import { Listing, Loan } from '../../utils/index.ts';
     * Investor
         * FIELDS
         * this.portfolio : Loan[]
-        * this.initialInvestment: numnber
         * this.currentCashBalance : number
         * this.model : IModel
         * this.monthlyAllocation : number
@@ -19,18 +18,16 @@ import { Listing, Loan } from '../../utils/index.ts';
 export class Investor{
     portfolio: Loan[];
     portfolioValue: number;
-    initialInvestment: number;
     currentCashBalance: number;
     model: IModel;
     monthlyAllocation: number;
     dailyAllocation: number[];
     name: string;
 
-    constructor(portfolio: Loan[], initialInvestment: number, currentCashBalance: number,
+    constructor(portfolio: Loan[], currentCashBalance: number,
                 model: IModel, monthlyAllocation: number, name: string) {
                     this.portfolio = portfolio;
                     this.portfolioValue = 0;
-                    this.initialInvestment = initialInvestment;
                     this.currentCashBalance = currentCashBalance;
                     this.model = model;
                     this.monthlyAllocation = monthlyAllocation;

--- a/supabase/functions/tests/testInvestor.ts
+++ b/supabase/functions/tests/testInvestor.ts
@@ -1,11 +1,11 @@
-import { assert } from "https://deno.land/std@0.214.0/assert/mod.ts";
+import { assertEquals } from "https://deno.land/std@0.214.0/assert/mod.ts";
 import { Investor } from "../backtest/investor/index.ts";
 import { ProsperZero } from "../model/index.ts";
 
 Deno.test("Test Investor.setAllocatian", () => {
     const investor1 = new Investor(
         [],
-        10000,
+        9999,
         new ProsperZero([]),
         1.0,
         "Investor 1",
@@ -13,10 +13,10 @@ Deno.test("Test Investor.setAllocatian", () => {
     // Set allocation on first of the month
     investor1.setAllocation(new Date(2000, 0, 1));
     const dailyAllocation: number[] = [
-        325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,300,300,300
+        325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,300,300,300,300
     ];
 
-    assert(investor1.dailyAllocation == dailyAllocation);
+    assertEquals(investor1.dailyAllocation, dailyAllocation);
 });
 
 // Deno.test("Test Investor.currentAllocation", () => {

--- a/supabase/functions/tests/testInvestor.ts
+++ b/supabase/functions/tests/testInvestor.ts
@@ -1,17 +1,33 @@
 import { assert } from "https://deno.land/std@0.214.0/assert/mod.ts";
-import { Investor } from '../backtest/investor/index.ts';
+import { Investor } from "../backtest/investor/index.ts";
 import { ProsperZero } from "../model/index.ts";
 
-Deno.test("Test Investor.currentAllocation", () => {
+Deno.test("Test Investor.setAllocatian", () => {
     const investor1 = new Investor(
         [],
         10000,
-        10000,
         new ProsperZero([]),
-        1000,
+        1.0,
+        "Investor 1",
     );
-    investor1.setAllocation(new Date(2014, 0, 1));
+    // Set allocation on first of the month
+    investor1.setAllocation(new Date(2000, 0, 1));
+    const dailyAllocation: number[] = [
+        325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,325,300,300,300
+    ];
 
-    assert(investor1.dailyAllocation[0] == 2);
+    assert(investor1.dailyAllocation == dailyAllocation);
 });
 
+// Deno.test("Test Investor.currentAllocation", () => {
+//     const investor1 = new Investor(
+//         [],
+//         10000,
+//         10000,
+//         new ProsperZero([]),
+//         1000,
+//     );
+//     investor1.setAllocation(new Date(2014, 0, 1));
+//
+//     assert(investor1.dailyAllocation[0] == 2);
+// });


### PR DESCRIPTION
- Remove unused field in Investor, Write test for setAllocation
- Update test

This pr fixes #25
There was no bug in the function, I think the reason the model doesn't spend its allocation is because a large number of loans lose money.
